### PR TITLE
chore: remove extract all deployment pages on initial extract event

### DIFF
--- a/apps/stack/src/extract/events.ts
+++ b/apps/stack/src/extract/events.ts
@@ -21,11 +21,6 @@ const metadataSchema = z.object({
   dbUrl: z.string(),
 });
 
-const FOURTEEN_DAYS_MS = 14 * 24 * 60 * 60 * 1000;
-export const isInitialExtractEvent = ({ metadata }: { metadata: z.infer<typeof metadataSchema> }) => {
-  return (metadata.to.getTime() - metadata.from.getTime()) > FOURTEEN_DAYS_MS;
-}
-
 const extractMergeRequestEventSchema = z.object({
   mergeRequestIds: z.array(MergeRequestSchema.shape.id),
   repositoryId: RepositorySchema.shape.id,


### PR DESCRIPTION
Simplify rate limit requirement calculation on extract process.
Changes manual historic data extraction process, but should be a net gain in reducing process errors